### PR TITLE
Prevent `addFiles` timing out on empty `filenames` array

### DIFF
--- a/janzip/janzip.js
+++ b/janzip/janzip.js
@@ -105,6 +105,10 @@ var Zip = function () {
                 }
             };
             
+            if (!filenames.length) {
+              return callback && callback(fileErr);
+            }
+            
             filenames.forEach(function (f) {
                 fs.readFile(f.path, function (err, data) {
                     if (err) {


### PR DESCRIPTION
If addFiles is passed an empty `filenames` array it will eventually 
timeout as the callback will never be called.  This change 
calls the callback immediately when `filenames.length` is 0.
